### PR TITLE
Improved classpath extraction from sourceSets

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -7,7 +7,7 @@ plugins {
 }
 
 group 'com.mborzenkov'
-version '0.2'
+version '0.2.1'
 description 'JQF: Feedback-directed Quickcheck for Java - Gradle plugin'
 
 compileJava {

--- a/src/main/java/com/mborzenkov/jqfgradleplugin/JqfUtil.java
+++ b/src/main/java/com/mborzenkov/jqfgradleplugin/JqfUtil.java
@@ -1,8 +1,13 @@
 package com.mborzenkov.jqfgradleplugin;
 
+import java.io.File;
 import java.util.ArrayList;
+import java.util.Collections;
 import java.util.List;
 import org.gradle.api.Project;
+import org.gradle.api.internal.tasks.DefaultSourceSet;
+import org.gradle.api.internal.tasks.DefaultSourceSetContainer;
+import org.gradle.api.tasks.SourceSetContainer;
 
 /**
  * Utility functions for JQF.
@@ -17,11 +22,19 @@ public class JqfUtil {
    *    classes dir
    */
   public static List<String> getTestClasspathElements(Project project) {
-    String buildDir = project.getBuildDir().getAbsolutePath();
-    List<String> list = new ArrayList<>(2);
-    list.add(buildDir + "/classes");
-    list.add(buildDir + "/classes/java/test");
-    list.add(buildDir + "/classes/java/main");
+    DefaultSourceSetContainer sourceSets =
+      (DefaultSourceSetContainer) project.getExtensions().getByName("sourceSets");
+    String[] mainClasspath = getSourceSetRuntimeClasspath(sourceSets, "main");
+    String[] testClasspath = getSourceSetRuntimeClasspath(sourceSets, "test");
+    List<String> list = new ArrayList<>();
+    Collections.addAll(list, mainClasspath);
+    Collections.addAll(list, testClasspath);
     return list;
+  }
+
+  private static String[] getSourceSetRuntimeClasspath(SourceSetContainer container, String name) {
+    DefaultSourceSet sourceSet = (DefaultSourceSet) container.getByName(name);
+    String runtimeClasspath = sourceSet.getRuntimeClasspath().getAsPath();
+    return runtimeClasspath.split(File.pathSeparator);
   }
 }


### PR DESCRIPTION
Fix #2

Now it's using source sets instead of hardcoded paths for extracting runtime classpaths.